### PR TITLE
chore: upgrade to next@13.0.1-canary.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@trpc/client": "^10.0.0-rc.1",
     "@trpc/react-query": "^10.0.0-rc.1",
     "@trpc/server": "^10.0.0-rc.1",
-    "next": "^13.0.0",
+    "next": "^13.0.1-canary.3",
     "next-auth": "4.14.0",
     "npm-run-all": "^4.1.5",
     "prisma": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   autoprefixer: ^10.4.13
   eslint: 8.25.0
   eslint-config-next: 12.3.1
-  next: ^13.0.0
+  next: ^13.0.1-canary.3
   next-auth: 4.14.0
   npm-run-all: ^4.1.5
   postcss: ^8.4.18
@@ -36,8 +36,8 @@ dependencies:
   '@trpc/client': 10.0.0-rc.1_@trpc+server@10.0.0-rc.1
   '@trpc/react-query': 10.0.0-rc.1_j3pstw3g7plkegerh6sxuce5zm
   '@trpc/server': 10.0.0-rc.1
-  next: 13.0.0_biqbaboplfbrettd7655fr4n2y
-  next-auth: 4.14.0_r5sq4deac3rmm2d5onhwvomqve
+  next: 13.0.1-canary.3_biqbaboplfbrettd7655fr4n2y
+  next-auth: 4.14.0_e25bmik2yuydrn55oi6haymzga
   npm-run-all: 4.1.5
   prisma: 4.5.0
   react: 18.2.0
@@ -119,8 +119,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@next/env/13.0.0:
-    resolution: {integrity: sha512-65v9BVuah2Mplohm4+efsKEnoEuhmlGm8B2w6vD1geeEP2wXtlSJCvR/cCRJ3fD8wzCQBV41VcMBQeYET6MRkg==}
+  /@next/env/13.0.1-canary.3:
+    resolution: {integrity: sha512-U8fqOuMAN+p6tKaLrlhZUs71+8sjyo0yqts0n3e6PSI/B18+yGl/n04A5PNt7+oOFXYxd7GRWYvP30fBTYbGmA==}
     dev: false
 
   /@next/eslint-plugin-next/12.3.1:
@@ -129,8 +129,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-android-arm-eabi/13.0.0:
-    resolution: {integrity: sha512-+DUQkYF93gxFjWY+CYWE1QDX6gTgnUiWf+W4UqZjM1Jcef8U97fS6xYh+i+8rH4MM0AXHm7OSakvfOMzmjU6VA==}
+  /@next/swc-android-arm-eabi/13.0.1-canary.3:
+    resolution: {integrity: sha512-c65jIL8Z5OYh0wa5fEIYPM83fBJ3Ilh0erPo4LmPWWH2aIJFZQf0hyRhUq1WWXTdIYklfmqqyWy2XvqAcazsWA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
@@ -138,8 +138,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-android-arm64/13.0.0:
-    resolution: {integrity: sha512-RW9Uy3bMSc0zVGCa11klFuwfP/jdcdkhdruqnrJ7v+7XHm6OFKkSRzX6ee7yGR1rdDZvTnP4GZSRSpzjLv/N0g==}
+  /@next/swc-android-arm64/13.0.1-canary.3:
+    resolution: {integrity: sha512-t4XJeV7+yLQfwbUlEbs1MfKvWrlanNeIkqNpIaMfKMcYyq1G9wayCyaNhwNktGJ9aVrP+32zdXZqp6I0C/ikzg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -147,8 +147,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-arm64/13.0.0:
-    resolution: {integrity: sha512-APA26nps1j4qyhOIzkclW/OmgotVHj1jBxebSpMCPw2rXfiNvKNY9FA0TcuwPmUCNqaTnm703h6oW4dvp73A4Q==}
+  /@next/swc-darwin-arm64/13.0.1-canary.3:
+    resolution: {integrity: sha512-rkK8ygQBdxqQTAmK8S5w7sMlQDdhUv22oZZJhGZC10q6E8BRZ4Zq5kMijdQJcYu16fszI5Z2oD0Dprs52nkwcw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -156,8 +156,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64/13.0.0:
-    resolution: {integrity: sha512-qsUhUdoFuRJiaJ7LnvTQ6GZv1QnMDcRXCIjxaN0FNVXwrjkq++U7KjBUaxXkRzLV4C7u0NHLNOp0iZwNNE7ypw==}
+  /@next/swc-darwin-x64/13.0.1-canary.3:
+    resolution: {integrity: sha512-R2nOigZObwiKCq7uR3ndB634jboufk07J8swwqyRKZVondb8TYHiMH30TzU5DxgqEy9fGX3B19cH6wrUqBv5iQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -165,8 +165,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-freebsd-x64/13.0.0:
-    resolution: {integrity: sha512-sCdyCbboS7CwdnevKH9J6hkJI76LUw1jVWt4eV7kISuLiPba3JmehZSWm80oa4ADChRVAwzhLAo2zJaYRrInbg==}
+  /@next/swc-freebsd-x64/13.0.1-canary.3:
+    resolution: {integrity: sha512-zDytQB28gHN7EscwaOytfvTpePlSzved8SUMBrNWwA/5TEzQAeNMGBV1pBZT4DxuBhTt5rbhOjeaKPztVHItGQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
@@ -174,8 +174,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm-gnueabihf/13.0.0:
-    resolution: {integrity: sha512-/X/VxfFA41C9jrEv+sUsPLQ5vbDPVIgG0CJrzKvrcc+b+4zIgPgtfsaWq9ockjHFQi3ycvlZK4TALOXO8ovQ6Q==}
+  /@next/swc-linux-arm-gnueabihf/13.0.1-canary.3:
+    resolution: {integrity: sha512-P9Z45kpEfJqFx0I1eUdqNnA3/RYiHn6g2j6rv3RqJFkli1xEoOsyDAVwmC+pDSXn0yl3/j2OJUABxRbfgqsnVQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -183,8 +183,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu/13.0.0:
-    resolution: {integrity: sha512-x6Oxr1GIi0ZtNiT6jbw+JVcbEi3UQgF7mMmkrgfL4mfchOwXtWSHKTSSPnwoJWJfXYa0Vy1n8NElWNTGAqoWFw==}
+  /@next/swc-linux-arm64-gnu/13.0.1-canary.3:
+    resolution: {integrity: sha512-iD+tX5PCt5rfKhfn+G0F4uT3JH9W7IZqadWQwkxpbY3xO3nj1kKOL1IXGdOFIPzX029XM3+bS6T9y1ep6iYjZg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -192,8 +192,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl/13.0.0:
-    resolution: {integrity: sha512-SnMH9ngI+ipGh3kqQ8+mDtWunirwmhQnQeZkEq9e/9Xsgjf04OetqrqRHKM1HmJtG2qMUJbyXFJ0F81TPuT+3g==}
+  /@next/swc-linux-arm64-musl/13.0.1-canary.3:
+    resolution: {integrity: sha512-G8VSFN0EY3NsUaJFXPYq3oAJuB8FuYBNkU6meosIBXprXfU+/GDKLY0vQkNpmTxt4X4LzREs3Jy60Iq+7nZikg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -201,8 +201,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu/13.0.0:
-    resolution: {integrity: sha512-VSQwTX9EmdbotArtA1J67X8964oQfe0xHb32x4tu+JqTR+wOHyG6wGzPMdXH2oKAp6rdd7BzqxUXXf0J+ypHlw==}
+  /@next/swc-linux-x64-gnu/13.0.1-canary.3:
+    resolution: {integrity: sha512-T0K2nSZB7dh3jSAWzX1tTh3WrIesp7Vg9tlMuSEGFV2jeo/JOQD5LVA5/F8hCNaZ0zPDlVNw5tXAPED0b0OpGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -210,8 +210,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl/13.0.0:
-    resolution: {integrity: sha512-xBCP0nnpO0q4tsytXkvIwWFINtbFRyVY5gxa1zB0vlFtqYR9lNhrOwH3CBrks3kkeaePOXd611+8sjdUtrLnXA==}
+  /@next/swc-linux-x64-musl/13.0.1-canary.3:
+    resolution: {integrity: sha512-EeX1aQpH7ZCRLexk5mlzMWPLP3XHwGlBzEuTSHHsGaTWo41rMHvW1E98BIXhvfYpbgQoj9MgLFh7/eIsH3GCDw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -219,8 +219,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc/13.0.0:
-    resolution: {integrity: sha512-NutwDafqhGxqPj/eiUixJq9ImS/0sgx6gqlD7jRndCvQ2Q8AvDdu1+xKcGWGNnhcDsNM/n1avf1e62OG1GaqJg==}
+  /@next/swc-win32-arm64-msvc/13.0.1-canary.3:
+    resolution: {integrity: sha512-sOGPGJAgmHg0AU+STkmtuF7s/6k2PZvgTk23Hz6VVtM27lXBZ3iVVXhVt8INGjDTDUwofgdJpNH4Db8UwYr74A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -228,8 +228,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc/13.0.0:
-    resolution: {integrity: sha512-zNaxaO+Kl/xNz02E9QlcVz0pT4MjkXGDLb25qxtAzyJL15aU0+VjjbIZAYWctG59dvggNIUNDWgoBeVTKB9xLg==}
+  /@next/swc-win32-ia32-msvc/13.0.1-canary.3:
+    resolution: {integrity: sha512-QiaRl+/UKp36YMSTzYTbcH/rJbEbU3V3Fjb0/N4ib6QFcM8WmsRVWC2iGVIba8GU7x5i7LrTwLxXaoevMAcH+w==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -237,8 +237,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc/13.0.0:
-    resolution: {integrity: sha512-FFOGGWwTCRMu9W7MF496Urefxtuo2lttxF1vwS+1rIRsKvuLrWhVaVTj3T8sf2EBL6gtJbmh4TYlizS+obnGKA==}
+  /@next/swc-win32-x64-msvc/13.0.1-canary.3:
+    resolution: {integrity: sha512-gvX+HHL31Nk1/cdlh0PxH65sFb4saUjGvD0SxurNAi0ibcH5I8hyvlEyVNUe59cwylLGjo1FKRDxaMTidoYScg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -717,13 +717,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  /caniuse-lite/1.0.30001419:
-    resolution: {integrity: sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==}
-    dev: false
-
   /caniuse-lite/1.0.30001426:
     resolution: {integrity: sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==}
-    dev: true
 
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1772,7 +1767,7 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-auth/4.14.0_r5sq4deac3rmm2d5onhwvomqve:
+  /next-auth/4.14.0_e25bmik2yuydrn55oi6haymzga:
     resolution: {integrity: sha512-pD5sin6kq/uIx3Cod2/0JFnViEnngBTTNy4CdfRaYc2QzV2zwpWAbQny2Ezlg0GjEozDhKC53JJxRRE4AmNKEw==}
     engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
     peerDependencies:
@@ -1788,7 +1783,7 @@ packages:
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
       jose: 4.10.0
-      next: 13.0.0_biqbaboplfbrettd7655fr4n2y
+      next: 13.0.1-canary.3_biqbaboplfbrettd7655fr4n2y
       oauth: 0.9.15
       openid-client: 5.1.10
       preact: 10.11.2
@@ -1798,15 +1793,15 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /next/13.0.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-puH1WGM6rGeFOoFdXXYfUxN9Sgi4LMytCV5HkQJvVUOhHfC1DoVqOfvzaEteyp6P04IW+gbtK2Q9pInVSrltPA==}
+  /next/13.0.1-canary.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-qWjbnUofZKIEDhGQaRidZUq5xth3GhOA1CrImBHpUlBpN55+o5Jc/hV/fAu2cK5oX/xxZDUV/+Xb9ApVkJ4tcw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
     peerDependencies:
       fibers: '>= 3.1.0'
       node-sass: ^6.0.0 || ^7.0.0
-      react: ^18.0.0-0
-      react-dom: ^18.0.0-0
+      react: ^18.2.0
+      react-dom: ^18.2.0
       sass: ^1.3.0
     peerDependenciesMeta:
       fibers:
@@ -1816,28 +1811,28 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.0.0
+      '@next/env': 13.0.1-canary.3
       '@swc/helpers': 0.4.11
-      caniuse-lite: 1.0.30001419
+      caniuse-lite: 1.0.30001426
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       styled-jsx: 5.1.0_react@18.2.0
       use-sync-external-store: 1.2.0_react@18.2.0
     optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.0.0
-      '@next/swc-android-arm64': 13.0.0
-      '@next/swc-darwin-arm64': 13.0.0
-      '@next/swc-darwin-x64': 13.0.0
-      '@next/swc-freebsd-x64': 13.0.0
-      '@next/swc-linux-arm-gnueabihf': 13.0.0
-      '@next/swc-linux-arm64-gnu': 13.0.0
-      '@next/swc-linux-arm64-musl': 13.0.0
-      '@next/swc-linux-x64-gnu': 13.0.0
-      '@next/swc-linux-x64-musl': 13.0.0
-      '@next/swc-win32-arm64-msvc': 13.0.0
-      '@next/swc-win32-ia32-msvc': 13.0.0
-      '@next/swc-win32-x64-msvc': 13.0.0
+      '@next/swc-android-arm-eabi': 13.0.1-canary.3
+      '@next/swc-android-arm64': 13.0.1-canary.3
+      '@next/swc-darwin-arm64': 13.0.1-canary.3
+      '@next/swc-darwin-x64': 13.0.1-canary.3
+      '@next/swc-freebsd-x64': 13.0.1-canary.3
+      '@next/swc-linux-arm-gnueabihf': 13.0.1-canary.3
+      '@next/swc-linux-arm64-gnu': 13.0.1-canary.3
+      '@next/swc-linux-arm64-musl': 13.0.1-canary.3
+      '@next/swc-linux-x64-gnu': 13.0.1-canary.3
+      '@next/swc-linux-x64-musl': 13.0.1-canary.3
+      '@next/swc-win32-arm64-msvc': 13.0.1-canary.3
+      '@next/swc-win32-ia32-msvc': 13.0.1-canary.3
+      '@next/swc-win32-x64-msvc': 13.0.1-canary.3
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros

--- a/server-rsc/getUser.tsx
+++ b/server-rsc/getUser.tsx
@@ -7,16 +7,16 @@ export interface User {
   name: string;
 }
 export async function getUser(): Promise<User | null> {
-  const $cookies = cookies();
-
-  const newCookies = new Map<string, string>();
-  for (const [key, value] of $cookies.entries()) {
-    newCookies.set(key, value.substr(key.length + 1).split(";")[0]);
-  }
+  const newCookies = cookies()
+    .getAll()
+    .reduce((cookiesObj, cookie) => {
+      cookiesObj[cookie.name] = cookie.value;
+      return cookiesObj;
+    }, {} as Record<string, string>);
 
   const token = await getToken({
     req: {
-      cookies: newCookies as any,
+      cookies: newCookies,
       headers: {},
     } as any,
   });


### PR DESCRIPTION
The `cookies.entries()` method doesn't seem to exist anymore, replace with `getAll()`. Using `Map` makes typescript sad:
```
Index signature for type 'string' is missing in type 'Map<string, string>'.
```
so replace it with object (still need another `any` since lots of `req` properties are missing).