### PR TITLE
fix: apply styles to the whole layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+import "./global.css";
+
 import Link from "next/link";
 import { ReactNode } from "react";
 import { ClientProvider } from "~/client/trpcClient";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,3 @@
-import "./global.css";
-
 import { Suspense, use } from "react";
 import { CreatePostForm } from "~/client/CreatePostForm";
 import { serialize } from "~/client/hydration";


### PR DESCRIPTION
If you go to [post URL](https://rsc.trpc.io/post/521cb110-e2dc-430d-b4fa-47547f501f39) directly, styles imported in `app/page.tsx` never get loaded. Import them globally on the `RootLayout` level (https://beta.nextjs.org/docs/styling/global-styles)
