### PR TITLE
fix: display the post immediately after creation

### DIFF
--- a/server/routers/post.ts
+++ b/server/routers/post.ts
@@ -26,7 +26,7 @@ export const postRouter = router({
     .input(
       z.object({
         limit: z.number().min(1).max(100).nullish(),
-        cursor: z.string().nullish(),
+        cursor: z.any(),
         initialCursor: z.string().nullish(),
       }),
     )
@@ -45,7 +45,7 @@ export const postRouter = router({
         // get an extra item to know if there's a next page
         take: limit + 1,
         where: {},
-        cursor: cursor
+        cursor: typeof cursor === 'string'
           ? {
               id: cursor,
             }


### PR DESCRIPTION
Currently the `curor` that's coming to `post.list` query is either `undefined | {}`, while `zod` expects a `string`. I sneak `any` here to confirm that it's the case - list is now refreshed as soon as post is created.

But the real question is - can we get rid of `cursor` at all? I also don't understand where `{}` comes from (I suppose `useInfiniteQuery` does that somehow).
